### PR TITLE
fix(package.json): add files field to remove unnecessary files in published package

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,10 @@
   },
   "main": "./dist/index.js",
   "bin": "./bin/index.js",
+  "files": [
+    "dist",
+    "bin"
+  ],
   "scripts": {
     "build": "rm -rf dist && tsup ./src/index.ts --format esm --dts",
     "dev": "yarn run build --watch",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -10,6 +10,10 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
+  "files": [
+    "dist",
+    "bin"
+  ],
   "scripts": {
     "build": "rm -rf dist && tsup ./src/index.ts --format esm --dts",
     "dev": "yarn run build --watch",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -14,6 +14,9 @@
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rm -rf dist && tsup ./src/index.ts ./src/testing/index.ts --format esm --dts",
     "dev": "yarn run build --watch",


### PR DESCRIPTION
## First of all, I really wanted to say thank you so so much for providing this cool package! 👍
I've been waiting too long for a package that can replace [`npx sort-package-json`](https://github.com/keithamus/sort-package-json) to be released.
This package completely eliminated my annoyance with running npx sort-package-json for every package in my monorepo:[suspensive/react](https://github.com/suspensive/react). Thank you thank you so much!

but I found some unnecessary files. so I make this Pull Request.

# Remove unncessary files in published package
You can see below link to check unnecessary files in published packlint.
https://www.npmjs.com/package/packlint?activeTab=explore

and installed package
![image](https://user-images.githubusercontent.com/61593290/217497976-8fcbce4d-a8b1-46de-820b-a3dfe35221cf.png)

Package.json's files field will remove them. check it please