### PR TITLE
docs(README.md): edit example of configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The Packlint configuration file is named `packlint.config.mjs`. It should be pla
 ```js
 // packlint.config.mjs
 export default {
-  files: ['./packages/**/package.json'],
+  files: ['./packages/*/package.json'],
   ignores: ['./package.json'],
   rules: {
     merge: {


### PR DESCRIPTION
# Edit README.md to remove chance of making mistake by beginners
I don't use Plug'n'play nodeLinker. so My monorepo:https://github.com/suspensive/react was having packages/*/node_modules.

## AS-IS: current guide to config packlint
```js
// packlint.config.mjs
```js
// packlint.config.mjs
export default {
  files: ['./packages/**/package.json'],
  ignores: ['./package.json'],
  rules: {
    merge: {  
      type: 'module',
      scripts: {
        prepack: 'yarn build',
        build: 'rm -rf dist && tsup ./src/index.ts --format esm --dts',
        dev: 'yarn run build --watch',
        typecheck: 'tsc --noEmit',
      },
      publishConfig: {
        access: 'public',
      },
    },
  },
};
```

but when I use packlint.config.mjs following as README.md's configuration guide, I met error like below picture.

![image](https://user-images.githubusercontent.com/61593290/217502326-28556f65-6eac-4be6-8047-d4740e6c3f48.png)

actually It's not really problem. because I fixed it after edit configuration file like this Pull Request's file changed.
but many package don't use Plug'n'Play yet, so I don't want to let leave obstacle for packlint beginner anymore.
It's why I make this Pull Request.

### Other context
Actually I think this Pull Request is not perfect solution. so I want to suggest other way to solve this problem:making packlint can ignore packages/*/node_modules defaultly, not configuration. I guess that packages/*/node_modules is not goal of packlint.