### PR TITLE
chore: upgrade TypeScript dependency to ^5.9.3 across all packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "packlint": "workspace:^",
     "prettier": "^2.7.1",
     "turbo": "^1.6.3",
-    "typescript": "4.8.3",
+    "typescript": "^5.9.3",
     "vite": "^4.0.2",
     "vitest": "^0.26.1"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "@types/node": "^18.11.9",
     "tsup": "^6.5.0",
-    "typescript": "4.8.3",
+    "typescript": "^5.9.3",
     "vite": "^4.0.2",
     "vitest": "^0.26.1"
   },

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -27,7 +27,7 @@
     "@types/node": "^18.11.9",
     "fast-check": "^3.3.0",
     "tsup": "^6.5.0",
-    "typescript": "4.8.3",
+    "typescript": "^5.9.3",
     "vite": "^4.0.2",
     "vitest": "^0.26.1",
     "zod-fast-check": "^0.8.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "@types/fs-extra": "^9.0.13",
     "fast-check": "^3.3.0",
     "tsup": "^6.5.0",
-    "typescript": "4.8.3",
+    "typescript": "^5.9.3",
     "vite": "^4.0.2",
     "vitest": "^0.26.1",
     "zod-fast-check": "^0.8.0"

--- a/packlint.config.mjs
+++ b/packlint.config.mjs
@@ -21,7 +21,7 @@ export default {
       },
       devDependencies: {
         tsup: '^6.5.0',
-        typescript: '4.8.3',
+        typescript: '^5.9.3',
         vite: '^4.0.2',
         vitest: '^0.26.1',
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,7 +1093,7 @@ __metadata:
     fast-check: "npm:^3.3.0"
     ramda: "npm:^0.28.0"
     tsup: "npm:^6.5.0"
-    typescript: "npm:4.8.3"
+    typescript: "npm:^5.9.3"
     vite: "npm:^4.0.2"
     vitest: "npm:^0.26.1"
     zod: "npm:3.19.1"
@@ -1115,7 +1115,7 @@ __metadata:
     fs-extra: "npm:^10.1.0"
     ramda: "npm:^0.28.0"
     tsup: "npm:^6.5.0"
-    typescript: "npm:4.8.3"
+    typescript: "npm:^5.9.3"
     vite: "npm:^4.0.2"
     vitest: "npm:^0.26.1"
     zod: "npm:^3.19.1"
@@ -5686,7 +5686,7 @@ __metadata:
     packlint: "workspace:^"
     prettier: "npm:^2.7.1"
     turbo: "npm:^1.6.3"
-    typescript: "npm:4.8.3"
+    typescript: "npm:^5.9.3"
     vite: "npm:^4.0.2"
     vitest: "npm:^0.26.1"
   languageName: unknown
@@ -5701,7 +5701,7 @@ __metadata:
     "@types/node": "npm:^18.11.9"
     clipanion: "npm:^3.2.0-rc.13"
     tsup: "npm:^6.5.0"
-    typescript: "npm:4.8.3"
+    typescript: "npm:^5.9.3"
     vite: "npm:^4.0.2"
     vitest: "npm:^0.26.1"
   bin:
@@ -7326,23 +7326,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:4.8.3":
-  version: 4.8.3
-  resolution: "typescript@npm:4.8.3"
+"typescript@npm:^5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/b7cd1fadba69a891edfbcaf1c5b9c8e7cbdbe979729ef7fdbe8bfa2818c8c141024e433d4430e874890400caf4afd6ab7baa7c2e247e39c9c7b5a80754804ac6
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A4.8.3#optional!builtin<compat/typescript>":
-  version: 4.8.3
-  resolution: "typescript@patch:typescript@npm%3A4.8.3#optional!builtin<compat/typescript>::version=4.8.3&hash=3b564f"
+"typescript@patch:typescript@npm%3A^5.9.3#optional!builtin<compat/typescript>":
+  version: 5.9.3
+  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/45179c7be9630a41e65f8e77de9aebf43f5b892141f49471e18aa9f79b6426f8d9d6e9482bf184ea7c05918bdebd1dd801993ddd31c21b8e6757fa429a36be77
+  checksum: 10c0/ad09fdf7a756814dce65bc60c1657b40d44451346858eea230e10f2e95a289d9183b6e32e5c11e95acc0ccc214b4f36289dcad4bf1886b0adb84d711d336a430
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This pull request upgrades the TypeScript version used throughout the project from `4.8.3` to `^5.9.3`.