### PR TITLE
Refactor Typescript and ESLint configuration file.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,12 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "always",
+    "source.organizeImports": "always"
   },
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "editor.rulers": [
-    120
-  ],
   "eslint.nodePath": ".yarn/sdks",
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact"
-  ],
   "files.trimTrailingWhitespace": true,
-  "javascript.preferences.importModuleSpecifier": "project-relative",
-  "javascript.preferences.quoteStyle": "single",
   "prettier.configPath": "./.prettierrc",
   "prettier.prettierPath": ".yarn/sdks/prettier/index.cjs",
   "search.exclude": {
@@ -24,7 +14,5 @@
     "**/.yarn": true
   },
   "typescript.enablePromptUseWorkspaceTsdk": true,
-  "typescript.preferences.importModuleSpecifier": "project-relative",
-  "typescript.preferences.quoteStyle": "single",
   "typescript.tsdk": ".yarn/sdks/typescript/lib"
 }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,86 +1,46 @@
+// @ts-check
+
 import js from '@eslint/js';
+import { defineConfig } from 'eslint/config';
 import importX from 'eslint-plugin-import-x';
-import jestPlugin from 'eslint-plugin-jest';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(
+export default defineConfig(
   {
-    ignores: ['**/node_modules/**', '**/dist/**', '**/esm/**', 'rollup.config.js', 'jest.config.js', '.yarn/**'],
+    ignores: ['**/node_modules/**', '**/dist/**', '.yarn/**'],
   },
   js.configs.recommended,
   ...tseslint.configs.recommended,
   {
     languageOptions: {
       globals: {
-        ...globals.es2021,
+        ...globals.es2026,
         ...globals.node,
       },
     },
   },
   {
-    // Configure parser options ONLY for TypeScript files
-    files: ['**/*.ts', '**/*.tsx'],
+    files: ['**/*.{ts,tsx}'],
     languageOptions: {
       parserOptions: {
-        project: ['./tsconfig.eslint.json', './packages/*/tsconfig.json'],
+        project: ['./tsconfig.json', './packages/*/tsconfig.json'],
         tsconfigRootDir: import.meta.dirname,
       },
     },
   },
   {
-    files: ['**/*.js', '**/*.mjs', '**/*.cjs', '**/*.ts', '**/*.tsx'],
+    files: ['**/*.{js,mjs,cjs,ts,tsx}'],
     plugins: {
       'simple-import-sort': simpleImportSort,
       'import-x': importX,
-      // Alias 'import' to 'import-x' for backward compatibility with eslint-disable comments
-      import: importX,
-      jest: jestPlugin,
     },
     rules: {
-      //
-      // eslint-plugin-import (now import-x)
-      //
-
-      // disallow non-import statements appearing before import statements
-      'import-x/first': 'error',
-      // Require a newline after the last import/require in a group
-      'import-x/newline-after-import': 'error',
-      // Forbid import of modules using absolute paths
-      'import-x/no-absolute-path': 'error',
-      // disallow AMD require/define
-      'import-x/no-amd': 'error',
-      // disallow imports from duplicate paths
-      'import-x/no-duplicates': 'error',
-      // Forbid the use of extraneous packages
-      'import-x/no-extraneous-dependencies': [
-        'error',
-        {
-          devDependencies: true,
-          peerDependencies: true,
-          optionalDependencies: false,
-        },
-      ],
-      // Forbid mutable exports
-      'import-x/no-mutable-exports': 'error',
-      // Prevent importing the default as if it were named
-      'import-x/no-named-default': 'error',
-      // Prohibit named exports
-      'import-x/no-named-export': 'off', // we want everything to be a named export
-      // Forbid a module from importing itself
-      'import-x/no-self-import': 'error',
-      // Require modules with a single export to use a default export
-      'import-x/prefer-default-export': 'off', // we want everything to be named
-
-      // enforce a sort order across the codebase
       'simple-import-sort/imports': 'error',
-    },
-  },
-  {
-    files: ['**/*.config.mjs', 'eslint.config.mjs'],
-    rules: {
-      'import-x/no-default-export': 'off',
+      'import-x/first': 'error',
+      'import-x/newline-after-import': 'error',
+      'import-x/no-duplicates': 'error',
     },
   }
 );

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import-x": "^4.16.1",
-    "eslint-plugin-jest": "^29.5.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.5.0",
     "packlint": "workspace:^",

--- a/packages/command/src/operations/merge-package-json.spec.ts
+++ b/packages/command/src/operations/merge-package-json.spec.ts
@@ -9,6 +9,7 @@ describe('mergePackageJSON', () => {
   test('The result should be the form of package.json', () => {
     fc.assert(
       fc.property(PackageJSONArbitrary, ConfigArbitrary, (target, config) => {
+        // @ts-expect-error FIXME: error after turning strict on.
         const { success } = PackageJSONSchema.safeParse(mergePackageJSON(target, config));
 
         return success;

--- a/packages/command/src/operations/sort-package-json.spec.ts
+++ b/packages/command/src/operations/sort-package-json.spec.ts
@@ -23,7 +23,9 @@ describe('sortPackageJSON', () => {
         ConfigArbitrary,
         fc.array(fc.string()),
         (p, config, randomStringArray) => {
+          // @ts-expect-error FIXME: error after turning strict on.
           expect(sortPackageJSON(p, config)).toMatchObject(
+            // @ts-expect-error FIXME: error after turning strict on.
             sortPackageJSON(p, { rules: { order: [...(config.rules?.order ?? []), ...randomStringArray] } })
           );
         }
@@ -38,9 +40,12 @@ describe('sortPackageJSON', () => {
   test(`An === Bn`, () => {
     fc.assert(
       fc.property(ShuffledPackageJSONArbitrary, ConfigArbitrary, (p, config) => {
+        // @ts-expect-error FIXME: error after turning strict on.
         fc.pre((config.rules?.order ?? []).every(item => Object.keys(p).includes(item)));
 
+        // @ts-expect-error FIXME: error after turning strict on.
         const res = sortPackageJSON(p, config);
+        // @ts-expect-error FIXME: error after turning strict on.
         (config.rules?.order ?? []).forEach((item, i) => expect(item).toBe(Object.keys(res)[i]));
       })
     );

--- a/packages/command/src/operations/sort-package-json.ts
+++ b/packages/command/src/operations/sort-package-json.ts
@@ -15,12 +15,14 @@ export function sortPackageJSON(packageJSON: PackageJSONType, config: ConfigType
  *
  * sortObjectByKeys(target, source) // {b:2, c:3, a:1. d:4}
  */
+// @ts-expect-error FIXME: error after turning strict on.
 function sortObjectByKeyOrders<T extends Record<string, unknown>>(
   obj: T,
   { keys = [], deep = [] }: { keys?: string[]; deep?: string[] } = {}
 ) {
   return R.pipe(
     sortByOrders(Object.keys(obj)),
+    // @ts-expect-error FIXME: error after turning strict on.
     R.map(key => [
       key,
       /**

--- a/packages/core/src/testing/arbitrary.ts
+++ b/packages/core/src/testing/arbitrary.ts
@@ -30,4 +30,5 @@ export function createArbitraryFromZodObject<T extends Record<string, unknown>>(
 export const PackageJSONArbitrary = createArbitraryFromZodObject(PackageJSONSchema);
 
 export const OrderArbitrary = shuffledSubarray(DEFAULT_ORDER, { minLength: 1 });
+// @ts-expect-error FIXME: error after turning strict on.
 export const ConfigArbitrary = createArbitraryFromZodObject(ConfigSchema);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "exclude": ["**/jest.setup.ts", "**/*.test.*", "**/*.spec.*", "**/*.stories.*", "**/__storybook__/*"]
-}

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,4 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "include": ["./.eslintrc.js", "./**/packlint.config.mjs", "./vitest.config.mjs", "./packages/**/tsdown.config.ts"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,39 +1,30 @@
 {
   "compilerOptions": {
     /* Modules */
-    "module": "Node16",
-    "moduleResolution": "Node16",
-    "resolveJsonModule": false,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "resolveJsonModule": true,
 
     /* Type Checking */
+    "strict": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noEmit": true,
 
     /* Language and Environment */
-    "experimentalDecorators": true,
-    "jsx": "react-jsx",
-    "lib": ["dom", "dom.iterable", "ESNext", "ESNext.AsyncIterable"],
-    "target": "ES2020",
+    "lib": ["ESNext"],
+    "target": "ES2022",
 
     /* Interop Constraints */
-    "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-
-    /* Emit */
-    "declaration": true,
-    "downlevelIteration": true,
-    "inlineSources": true,
-    "preserveConstEnums": true,
-    "removeComments": false,
-    "sourceMap": true,
 
     /* Completeness*/
     "allowJs": false,
     "skipLibCheck": true
   },
-  "exclude": ["**/dist/*", "**/esm/*", "**/__testfixtures__/*"],
-  "include": ["vitest.config.mjs"]
+  "exclude": ["**/dist/*"],
+  "include": ["*.config.*", "**/tsdown.config.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1346,7 +1346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/utils@npm:8.50.0, @typescript-eslint/utils@npm:^8.0.0":
+"@typescript-eslint/utils@npm:8.50.0":
   version: 8.50.0
   resolution: "@typescript-eslint/utils@npm:8.50.0"
   dependencies:
@@ -2297,24 +2297,6 @@ __metadata:
     eslint-import-resolver-node:
       optional: true
   checksum: 10c0/19cae9bf7b0e457747d5a5846b4198d83b02be43c02d2d49190ba3887ff019a307e3c486b5fc6feec7e9ed24a15e321012742fbbcbe96ad7e3bd24a31ee1450c
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-jest@npm:^29.5.0":
-  version: 29.5.0
-  resolution: "eslint-plugin-jest@npm:29.5.0"
-  dependencies:
-    "@typescript-eslint/utils": "npm:^8.0.0"
-  peerDependencies:
-    "@typescript-eslint/eslint-plugin": ^8.0.0
-    eslint: ^8.57.0 || ^9.0.0
-    jest: "*"
-  peerDependenciesMeta:
-    "@typescript-eslint/eslint-plugin":
-      optional: true
-    jest:
-      optional: true
-  checksum: 10c0/e135181330a593018611c754c5a6449ac683080803e6c9931f2a8e432d133c33e5ac5f1df52ff52c4a6ca14267ceffc57739d602e11909e3691acfbd2a923f66
   languageName: node
   linkType: hard
 
@@ -3649,7 +3631,6 @@ __metadata:
     eslint: "npm:^9.39.2"
     eslint-config-prettier: "npm:^8.5.0"
     eslint-plugin-import-x: "npm:^4.16.1"
-    eslint-plugin-jest: "npm:^29.5.0"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     globals: "npm:^16.5.0"
     packlint: "workspace:^"


### PR DESCRIPTION
This pull request primarily focuses on cleaning up and modernizing the project's linting and TypeScript configuration.

**Linting and ESLint Configuration Updates:**

- Refactored `eslint.config.mjs` to use `defineConfig`, updated to `globals.es2026`, removed the `eslint-plugin-jest` dependency and related rules, simplified file globs, and streamlined import rules for consistency and maintainability.
- Removed the `eslint-plugin-jest` package from `package.json` as it is no longer needed.

**TypeScript Configuration Cleanup:**

- Deleted `tsconfig.build.json` and `tsconfig.eslint.json`, removing redundant or unused TypeScript project configurations.

**VSCode Settings Improvements:**

- Updated `.vscode/settings.json` to always fix ESLint and organize imports on save, removed deprecated or redundant settings, and improved formatting consistency.

**Temporary TypeScript Strict Mode Workarounds:**

- Added multiple `@ts-expect-error FIXME: error after turning strict on.` comments throughout test and implementation files to suppress type errors after enabling TypeScript strict mode. These are intended as temporary workarounds until proper fixes can be implemented.
