### PR TITLE
chore: Update typescript-eslint settings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,9 @@
 // @ts-check
 
-import js from '@eslint/js';
-import { defineConfig } from 'eslint/config';
+import eslint from '@eslint/js';
 import importX from 'eslint-plugin-import-x';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';
+import { defineConfig } from 'eslint/config';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
@@ -11,27 +11,28 @@ export default defineConfig(
   {
     ignores: ['**/node_modules/**', '**/dist/**', '.yarn/**'],
   },
-  js.configs.recommended,
-  ...tseslint.configs.recommended,
+  eslint.configs.recommended,
+  tseslint.configs.recommended,
   {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: ['./tsconfig.json', './packages/**/tsconfig.json'],
+      },
+    },
+    rules: {
+      '@typescript-eslint/strict-boolean-expressions': 'error',
+    },
+  },
+  {
+    files: ['**/*.{js,mjs,cjs,ts,tsx}'],
     languageOptions: {
       globals: {
         ...globals.es2026,
         ...globals.node,
       },
     },
-  },
-  {
-    files: ['**/*.{ts,tsx}'],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.json', './packages/*/tsconfig.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-  },
-  {
-    files: ['**/*.{js,mjs,cjs,ts,tsx}'],
     plugins: {
       'simple-import-sort': simpleImportSort,
       'import-x': importX,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "@eslint/js": "^9.39.2",
     "@types/node": "^24.10.0",
     "eslint": "^9.39.2",
-    "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import-x": "^4.16.1",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "globals": "^16.5.0",

--- a/packages/command/src/commands/Base.ts
+++ b/packages/command/src/commands/Base.ts
@@ -16,6 +16,7 @@ export abstract class PacklintCommand<T extends BaseContext & { config: ConfigTy
 
   abstract write: boolean;
 
+  // eslint-disable-next-line no-unused-vars
   abstract action(json: PackageJSONType, config: ConfigType): Promise<PackageJSONType>;
 
   async run(_path = `${process.cwd()}/package.json`): Promise<PackageJSONType> {

--- a/packages/core/src/operations/get-config.ts
+++ b/packages/core/src/operations/get-config.ts
@@ -19,7 +19,7 @@ export async function getConfig({ cwd }: { cwd: string } = { cwd: process.cwd() 
 
   const parentPath = path.resolve(path.dirname(_path), config.extends);
 
-  if (!pathExists(parentPath)) {
+  if (!(await pathExists(parentPath))) {
     return config;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,17 +2248,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^8.5.0":
-  version: 8.5.0
-  resolution: "eslint-config-prettier@npm:8.5.0"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 10c0/e01efe3a30cc7a9d4944242b7944c4488514dfa198707d268474e1b938c6b8d1be1320c40ad01f1f3cde93bf393770b2d013e709c8411d41d9d0421fff86a12a
-  languageName: node
-  linkType: hard
-
 "eslint-import-context@npm:^0.1.9":
   version: 0.1.9
   resolution: "eslint-import-context@npm:0.1.9"
@@ -3629,7 +3618,6 @@ __metadata:
     "@eslint/js": "npm:^9.39.2"
     "@types/node": "npm:^24.10.0"
     eslint: "npm:^9.39.2"
-    eslint-config-prettier: "npm:^8.5.0"
     eslint-plugin-import-x: "npm:^4.16.1"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     globals: "npm:^16.5.0"


### PR DESCRIPTION
This pull request updates the ESLint configuration and related code to improve TypeScript support, enforce stricter linting rules, and fix minor issues. The most important changes are grouped below.

**ESLint Configuration Improvements:**

* Switched from `js.configs.recommended` to `eslint.configs.recommended` for base ESLint configuration, ensuring better compatibility with the latest ESLint ecosystem.
* Updated TypeScript configuration to use `typescript-eslint` parser and stricter rules, including enabling the `@typescript-eslint/strict-boolean-expressions` rule for enhanced type safety.
* Changed TypeScript project glob pattern from `./packages/*/tsconfig.json` to `./packages/**/tsconfig.json` for broader coverage.
* Removed the unused `eslint-config-prettier` dependency from `package.json` to clean up project dependencies.

**Code Quality and Bug Fixes:**

* Fixed an asynchronous bug in `getConfig` by awaiting the `pathExists` check, ensuring correct config file resolution.
* Added an ESLint directive to suppress the `no-unused-vars` warning for the abstract `action` method parameter in `Base.ts`, improving code clarity for future maintainers.