### PR TITLE
test: add CLI e2e tests with fixtures

### DIFF
--- a/__fixtures__/sorted/package.json
+++ b/__fixtures__/sorted/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "sorted-package",
+  "version": "1.0.0",
+  "description": "A sorted package"
+}

--- a/__fixtures__/unsorted/package.json
+++ b/__fixtures__/unsorted/package.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.0.0",
+  "name": "unsorted-package",
+  "description": "An unsorted package"
+}

--- a/packages/cli/src/__snapshots__/cli.test.ts.snap
+++ b/packages/cli/src/__snapshots__/cli.test.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`packlint CLI > sorted > check 1`] = `
+"[success] [packlint] No issues found.
+"
+`;
+
+exports[`packlint CLI > unsorted > check 1`] = `
+"[log] [packlint]  FIXABLE  ⚠ package.json keys are not sorted correctly. (package.json)
+"
+`;
+
+exports[`packlint CLI > unsorted > fix 1`] = `
+"{
+  "name": "unsorted-package",
+  "version": "1.0.0",
+  "description": "An unsorted package"
+}
+"
+`;

--- a/packages/cli/src/cli.test.ts
+++ b/packages/cli/src/cli.test.ts
@@ -1,0 +1,54 @@
+import { execSync } from 'child_process';
+import { readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const fixturesDir = join(__dirname, '../../../__fixtures__');
+const cli = join(__dirname, '../dist/main.mjs');
+
+const run = (args: string, cwd: string) => {
+  try {
+    return execSync(`node ${cli} ${args}`, {
+      cwd,
+      encoding: 'utf-8',
+      env: { ...process.env, NO_COLOR: '1' },
+    });
+  } catch (e: unknown) {
+    return (e as { stdout: string }).stdout;
+  }
+};
+
+describe('packlint CLI', () => {
+  describe('sorted', () => {
+    const cwd = join(fixturesDir, 'sorted');
+
+    it('check', () => {
+      const result = run('package.json', cwd);
+      expect(result).toMatchSnapshot();
+    });
+  });
+
+  describe('unsorted', () => {
+    const cwd = join(fixturesDir, 'unsorted');
+    const pkgPath = join(cwd, 'package.json');
+    let original: string;
+
+    afterEach(() => {
+      writeFileSync(pkgPath, original);
+    });
+
+    it('check', () => {
+      original = readFileSync(pkgPath, 'utf-8');
+      const result = run('package.json', cwd);
+      expect(result).toMatchSnapshot();
+    });
+
+    it('fix', () => {
+      original = readFileSync(pkgPath, 'utf-8');
+      run('package.json --fix', cwd);
+      const fixed = readFileSync(pkgPath, 'utf-8');
+      expect(fixed).toMatchSnapshot();
+    });
+  });
+
+});


### PR DESCRIPTION
Added CLI e2e tests using fixture-based snapshot testing.

Fixtures at root (`__fixtures__/`) to avoid yarn workspace detection.

Test cases:
- `sorted`: Already sorted → "No issues found"
- `unsorted`: Wrong order → Reports error, `--fix` reorders correctly