### PR TITLE
fix: allow sideEffects string arrays

### DIFF
--- a/.changeset/early-buses-remain.md
+++ b/.changeset/early-buses-remain.md
@@ -1,0 +1,5 @@
+---
+'@packlint/core': patch
+---
+
+Allow `sideEffects` to accept string arrays in package manifests.

--- a/packages/core/src/models/PackageJSON.spec.ts
+++ b/packages/core/src/models/PackageJSON.spec.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'vitest';
+
+import { PackageJSONSchema, PackageJSONType } from './PackageJSON.js';
+
+describe('PackageJSONSchema', () => {
+  test('accepts boolean sideEffects', () => {
+    expect(PackageJSONSchema.parse({ sideEffects: false })).toEqual({ sideEffects: false });
+  });
+
+  test('accepts string array sideEffects', () => {
+    const packageJSON: PackageJSONType = { sideEffects: ['*.css', './src/polyfill.js'] };
+
+    expect(PackageJSONSchema.parse(packageJSON)).toEqual(packageJSON);
+  });
+});

--- a/packages/core/src/models/PackageJSON.ts
+++ b/packages/core/src/models/PackageJSON.ts
@@ -37,7 +37,7 @@ export const PackageJSONSchema = z
       license: z.string(),
       author: z.union([PersonSchema, z.string()]),
       contributors: z.array(PersonSchema),
-      sideEffects: z.boolean(),
+      sideEffects: z.union([z.boolean(), z.array(z.string())]),
       packageManager: z.string().describe('Experimental: https://nodejs.org/api/packages.html#packagemanager'),
       type: z.enum(['commonjs', 'module']),
       exports: ExportsSchema,


### PR DESCRIPTION
allow package.json sideEffects to be either a boolean or an array of strings

- add schema regression coverage for both supported forms
- keep the change scoped to the package.json model validation