### PR TITLE
fix(PackageJSONSchema): allow funding string arrays

### DIFF
--- a/.changeset/calm-funds-appear.md
+++ b/.changeset/calm-funds-appear.md
@@ -1,0 +1,5 @@
+---
+'@packlint/core': patch
+---
+
+Allow `funding` arrays to contain both string and object entries.

--- a/packages/core/src/models/PackageJSON.spec.ts
+++ b/packages/core/src/models/PackageJSON.spec.ts
@@ -3,6 +3,14 @@ import { describe, expect, test } from 'vitest';
 import { PackageJSONSchema, PackageJSONType } from './PackageJSON.js';
 
 describe('PackageJSONSchema', () => {
+  test('accepts string and object entries in funding arrays', () => {
+    const packageJSON: PackageJSONType = {
+      funding: ['https://example.com/sponsor', { type: 'individual', url: 'https://example.com/donate' }],
+    };
+
+    expect(PackageJSONSchema.parse(packageJSON)).toEqual(packageJSON);
+  });
+
   test('accepts boolean sideEffects', () => {
     expect(PackageJSONSchema.parse({ sideEffects: false })).toEqual({ sideEffects: false });
   });

--- a/packages/core/src/models/PackageJSON.ts
+++ b/packages/core/src/models/PackageJSON.ts
@@ -4,6 +4,8 @@ import { ExportsSchema } from './Exports.js';
 import { PackageJSONErrorMap } from './PackageJSONError.js';
 import { PersonSchema } from './Person.js';
 
+const FundingEntrySchema = z.union([z.object({ type: z.string(), url: z.string() }), z.string()]);
+
 export const PackageJSONSchema = z
   .object(
     {
@@ -29,11 +31,7 @@ export const PackageJSONSchema = z
         }),
         z.string(),
       ]),
-      funding: z.union([
-        z.object({ type: z.string(), url: z.string() }),
-        z.string(),
-        z.array(z.object({ type: z.string(), url: z.string() }), z.string()),
-      ]),
+      funding: z.union([FundingEntrySchema, z.array(FundingEntrySchema)]),
       license: z.string(),
       author: z.union([PersonSchema, z.string()]),
       contributors: z.array(PersonSchema),


### PR DESCRIPTION
## Summary

- Allow npm `package.json` `funding` arrays to contain both URL strings and objects.
- Extract `FundingEntrySchema` so single values and array entries share the same validation rules.
- Add regression coverage for a mixed string and object array.
- Add a patch changeset for `@packlint/core`.

Reference: [npm package.json funding field](https://docs.npmjs.com/files/package.json/#funding)

## Test plan

- [x] `yarn eslint packages/core/src/models/PackageJSON.ts packages/core/src/models/PackageJSON.spec.ts`
- [x] `yarn typecheck`
- [x] `yarn vitest run --testTimeout=30000` — 3 files and 6 tests passed
- [x] `yarn build`

The default `yarn test:all` command exceeded the existing 10-second timeout in the property-based test in `sort-package-json.spec.ts` on local Windows. The same test passed when run alone, and the full suite passed with a 30-second timeout.
